### PR TITLE
Todo_listをStreamProviderで管理するように変更

### DIFF
--- a/lib/domain/repositories/implements/todo_repository_impl.dart
+++ b/lib/domain/repositories/implements/todo_repository_impl.dart
@@ -22,6 +22,7 @@ class FirebaseTodoRepository implements ITodoRepository {
     return _firestore.collection('users/$_userId/$_collection');
   }
 
+  // map処理がFirestoreのデータ変更のたびに実行される
   @override
   Stream<List<TodoModel>> getAllTodos() {
     if (_userId == null) {

--- a/lib/infrastructure/repository_provider.dart
+++ b/lib/infrastructure/repository_provider.dart
@@ -11,7 +11,7 @@ final authRepositoryProvider = Provider<IAuthRepository>((ref) {
   return FirebaseAuthRepository();
 });
 
-// Todoリポジトリプロバイダ
+// Todoリポジトリプロバイダー
 final todoRepositoryProvider = Provider<ITodoRepository>((ref) {
   final userId = ref.watch(currentUserIdProvider);
   return FirebaseTodoRepository(userId: userId);

--- a/lib/presentation/core/messages/auth_error_message.dart
+++ b/lib/presentation/core/messages/auth_error_message.dart
@@ -1,0 +1,26 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+String getErrorMessage(FirebaseAuthException error) {
+  switch (error.code) {
+    case 'user-not-found':
+      return 'メールアドレスが見つかりません';
+    case 'wrong-password':
+      return 'パスワードが間違っています';
+    case 'email-already-in-use':
+      return 'このメールアドレスは既に使用されています';
+    case 'weak-password':
+      return 'パスワードが弱すぎます';
+    case 'invalid-email':
+      return 'メールアドレスの形式が正しくありません';
+    case 'user-disabled':
+      return 'このアカウントは無効になっています';
+    case 'too-many-requests':
+      return 'リクエストが多すぎます。しばらく待ってから再試行してください';
+    case 'operation-not-allowed':
+      return 'この操作は許可されていません';
+    case 'network-request-failed':
+      return 'ネットワークエラーが発生しました';
+    default:
+      return '認証エラーが発生しました';
+  }
+}

--- a/lib/presentation/providers/auth_actions_provider.dart
+++ b/lib/presentation/providers/auth_actions_provider.dart
@@ -1,0 +1,138 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:todo/infrastructure/auth_provider.dart';
+import 'package:todo/infrastructure/repository_provider.dart';
+import 'package:todo/presentation/core/messages/auth_error_message.dart';
+import 'package:todo/presentation/providers/todo_provider.dart';
+
+// AuthActionsを提供するプロバイダー
+final authActionsProvider = Provider<AuthActions>((ref) {
+  return AuthActions(ref);
+});
+
+// ユースケースの役割
+class AuthActions {
+  final Ref _ref;
+
+  AuthActions(this._ref);
+
+  // メールとパスワードでサインイン
+  Future<void> signInWithEmailAndPassword(
+    String email,
+    String password,
+    VoidCallback onSuccess,
+    Function(String) onError,
+  ) async {
+    _ref.read(authActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      final authRepository = _ref.read(authRepositoryProvider);
+      await authRepository.signInWithEmailAndPassword(email, password);
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+      onSuccess;
+    } on FirebaseAuthException catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError(getErrorMessage(e));
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError('エラーが発生しました');
+    }
+  }
+
+  // メールとパスワードで会員登録
+  Future<void> createUserWithEmailAndPassword(
+    String email,
+    String password,
+    VoidCallback onSuccess,
+    Function(String) onError,
+  ) async {
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      final authRepository = _ref.read(authRepositoryProvider);
+      await authRepository.createUserWithEmailAndPassword(email, password);
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+      onSuccess;
+    } on FirebaseAuthException catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError(getErrorMessage(e));
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError('エラーが発生しました');
+    }
+  }
+
+  // Googleでサインイン
+  Future<void> signInWithGoogle(
+    VoidCallback onSuccess,
+    Function(String) onError,
+  ) async {
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      final authRepository = _ref.read(authRepositoryProvider);
+      await authRepository.signInWithGoogle();
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+      onSuccess();
+    } on FirebaseAuthException catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError(getErrorMessage(e));
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError('エラーが発生しました');
+    }
+  }
+
+  // サインアウト
+  Future<void> signOut() async {
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      final authRepository = _ref.read(authRepositoryProvider);
+      await authRepository.signOut();
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+    }
+  }
+
+  // パスワードリセットメールの送信
+  Future<void> resetPassword(
+    String email,
+    VoidCallback onSuccess,
+    Function(String) onError,
+  ) async {
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      final authRepository = _ref.read(authRepositoryProvider);
+      await authRepository.sendPasswordResetEmail(email);
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+      onSuccess;
+    } on FirebaseAuthException catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError(getErrorMessage(e));
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      onError('エラーが発生しました');
+    }
+  }
+}

--- a/lib/presentation/providers/todo_provider.dart
+++ b/lib/presentation/providers/todo_provider.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:todo/domain/entities/todo_model.dart';
+import 'package:todo/infrastructure/repository_provider.dart';
+import 'package:uuid/uuid.dart';
+
+// 未完了Todoを監視するストリームプロバイダー
+final incompleteTodoProvider = StreamProvider<List<TodoModel>>((ref) {
+  final todoRepository = ref.watch(todoRepositoryProvider);
+  return todoRepository.getInCompletedTodo();
+});
+
+// 完了したTodoを監視するストリームプロバイダー
+final completeTodoProvider = StreamProvider<List<TodoModel>>((ref) {
+  final todoRepository = ref.watch(todoRepositoryProvider);
+  return todoRepository.getCompletedTodo();
+});
+
+// すべてのTodoを監視するストリームプロバイダー
+final allTodoProvider = StreamProvider<List<TodoModel>>((ref) {
+  final todoRepository = ref.watch(todoRepositoryProvider);
+  return todoRepository.getAllTodos();
+});
+
+// todoアクションの状態を管理するプロバイダー
+final todoActionStateProvider = StateProvider<AsyncValue<void>>((ref) {
+  return const AsyncValue.data(null);
+});
+
+// Todo操作用のプロバイダ
+final todoActionsProvider = Provider<TodoActions>((ref) {
+  return TodoActions(ref);
+});
+
+// Todo操作を行うクラス
+class TodoActions {
+  final Ref _ref;
+
+  TodoActions(this._ref);
+
+  // Todo追加
+  Future<void> createTodo(
+    String todoTitle,
+    DateTime? dueDate,
+    bool important,
+  ) async {
+    final repository = _ref.read(todoRepositoryProvider);
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      final newTodo = TodoModel(
+        id: const Uuid().v4(),
+        todoTitle: todoTitle,
+        dueDate: dueDate,
+        createdDate: DateTime.now(),
+        important: important,
+        isCompleted: false,
+      );
+
+      // FirestoreにTodoを追加
+      await repository.addTodo(newTodo);
+
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      rethrow;
+    }
+  }
+
+  // Todo削除
+  Future<void> deleteTodo(String id) async {
+    final repository = _ref.read(todoRepositoryProvider);
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      await repository.deleteTodo(id);
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      rethrow;
+    }
+  }
+
+  // Todo更新
+  Future<void> updateTodo(
+    String todoTitle,
+    DateTime? dueDate,
+    bool important,
+    String todoId,
+  ) async {
+    final repository = _ref.read(todoRepositoryProvider);
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      // 現在のTodo取得
+      final allTodosAsync = await _ref.read(allTodoProvider.future);
+      final todoToUpdate =
+          allTodosAsync.firstWhere((todo) => todo.id == todoId);
+
+      // 更新されたTodoを作成
+      final updateTodo = todoToUpdate.copyWith(
+        todoTitle: todoTitle,
+        dueDate: dueDate,
+        important: important,
+      );
+
+      await repository.updateTodo(updateTodo);
+
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      rethrow;
+    }
+  }
+
+  Future<void> toggleTodo(TodoModel todo) async {
+    final repository = _ref.read(todoRepositoryProvider);
+    _ref.read(todoActionStateProvider.notifier).state =
+        const AsyncValue.loading();
+
+    try {
+      await repository.setTodoCompleted(todo, !todo.isCompleted);
+
+      _ref.read(todoActionStateProvider.notifier).state =
+          const AsyncValue.data(null);
+    } on Exception catch (e, _) {
+      _ref.read(todoActionStateProvider.notifier).state =
+          AsyncValue.error(e, _);
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
## ticket

#30 

## 概要

- 変更前：Todo_ListはtodoListProvider（AsyncNotifierProvider）で管理
- 変更後：Stream型のデータ（FirestoreからTodoを取得）をStreamProviderで管理
- UI側は未実装。エラーを回避するためにtodo_listは削除せずそのままにしてある